### PR TITLE
add example usage from forum post to readme, add event format notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,51 @@ e2-header.py - Edit file header to load sampler firmware on synth hardware
 e2-init-pat.py - Insert custom init pattern in electribe 2 sampler firmware version 2.02
 
 e2_syx_codec.py - Encode/Decode bytes to and from electribe SysEx format
+
+
+## Example Usage
+
+Print info on patterns found in file.e2ev:
+```
+python e2ev.py file.e2ev -i
+```
+
+
+Split a multi pattern event recording into multiple single pattern event recordings:
+```
+python e2ev.py file.e2ev -s
+```
+
+
+Create a stem event recording consisting of parts 1, 5 and 16 named 'drums':
+```
+python e2ev.py file.e2ev -c 0 4 15 -n drums
+```
+This will create file_drums_stem.e2ev
+
+
+
+Mute channel 16 of the event recording:
+```
+python e2ev.py file.e2ev -m 15
+```
+This will overwrite the original file.e2ev
+
+
+
+Extract all patterns files found in file.e2ev:
+```
+python e2ev.py file.e2ev -e
+```
+Patterns will be saved as file_pat_x.e2pat
+
+
+
+Replace the second pattern of file.e2ev with pattern.e2pat:
+```
+python e2ev.py file.e2ev -r 1 -p pattern.e2pat
+```
+
+### Extra information
+
+More information about the event recording format can be [found here](event-recording-notes.txt).

--- a/event-recording-notes.txt
+++ b/event-recording-notes.txt
@@ -1,0 +1,83 @@
+electribe 2 event recording file format
+
+list of 16 byte event messages
+time is delta time in ms
+
+for control events:
+	byte[4] 	= 	1
+	byte[6] 	= 	channel
+	byte[8] 	= 	parameter
+	byte[12:13] = 	value
+
+for note events:
+	byte[4] 	=	0
+	byte[8]		=	note On or Off : channel
+	byte[9] 	=	note number
+	byte[10]	=	velocity
+	byte[11]	=	1
+
+
+checksum in header at byte[260] is (file_size - 288)
+
+
+channel control:
+[	0	|	1	|	2	|	3	|	4	|	5	|	6	|	7	|	8	|	9	|	10	|	11	|	12	|	13	|	14	|	15	]
+---------------------------------------------------------------------------------------------------------------------------------
+[ time	| time	| null	| null	| 	01	| null  | chan	| null	| param	| null	|	FF	| 	FF 	|	lsb	|	msb	| null	| null	]
+[-------------------------------------------------------------------------------------------------------------------------------]
+
+
+pattern control:
+[	0	|	1	|	2	|	3	|	4	|	5	|	6	|	7	|	8	|	9	|	10	|	11	|	12	|	13	|	14	|	15	]
+---------------------------------------------------------------------------------------------------------------------------------
+[ time	| time	| null	| null	| 	01	| null	|  00	| null	| param	| null	|	FF	| 	FF 	|	lsb	|	msb	| null	| null	]
+[-------------------------------------------------------------------------------------------------------------------------------]
+
+
+note event:
+[	0	|	1	|	2	|	3	|	4	|	5	|	6	|	7	|	8	|	9	|	10	|	11	|	12	|	13	|	14	|	15	]
+---------------------------------------------------------------------------------------------------------------------------------
+[ time	| time	| null	| null	| 	00	| null	| null	| null	|onof:ch| note  |	vel	| 	01  |  null	|  null	| null	| null	]
+[-------------------------------------------------------------------------------------------------------------------------------]
+
+
+ev control change parameter numbers
+
+pattern parameters:
+
+tempo			00
+pattern level	01	
+mfx pad touched	02		
+mfx type		03
+mfx x			04	
+mfx y			05			
+mfx hold		06	
+alt 13/14		07
+alt 15/16		08
+
+
+part parameters:
+
+mono / poly		13
+motion type		14
+priority		17
+osc type		18		0x00 - 0x198
+osc pitch 		1a		x40 < x00 < x3f		-64 < 0 < 63
+glide			1b											
+osc edit		1c		
+filtype			1d												
+filter cut 		1e
+res 			1f
+eg				20
+mod type		21		0x00 - 0x47
+mod sp			22
+mod depth		23
+attack			24
+decay			25		
+lev				26
+pan				27
+ampegon			28	
+mfxsend			29
+ifx type		2a		0x00 - 0x25
+ifx edit		2b
+ifxon			2c


### PR DESCRIPTION
I found your excellent example usage post on the forum and thought it might help others to have it included in the readme.

I also found the event recording file format notes **very** useful so thought it would be good to have them preserved here rather than just in the pastebin.

Thanks again for all your work on making this information available!